### PR TITLE
fix tr-909 logo in darkreader

### DIFF
--- a/sass/909.sass
+++ b/sass/909.sass
@@ -45,6 +45,7 @@ div.tr-909
     width: 270px
     height: 35px
     background-repeat: no-repeat
+    background-size: contain
     background-image: url("../svg/tr-909.svg")
 
   > div.rhythm-composer-logo


### PR DESCRIPTION
Hi, this is very minor probably, feel free to cancel the PR, but when viewing the project and Dark reader extension is on, the SVG logo spills and crops like shown here:

![tr-909-before](https://user-images.githubusercontent.com/283907/173624397-b67c0d2e-1c64-443c-8a4b-06cfaa11515b.png)

However with this minor change it appears correctly (never mind the colors are because of dark reader trying to fix them):

![tr-909-logo-after](https://user-images.githubusercontent.com/283907/173624404-bb377135-526d-478f-bf70-7c5cff9d1a6c.png)

Still, it's very minor and only a problem if you use Dark reader, but no reason to appear broken IMO for those people who use the extension (like me :p)

Anyways, nice work! Is there a plan to make this functional in the future? Would be fun to play around! Cheers :)


